### PR TITLE
3.0

### DIFF
--- a/docs/Scheduling/EncounterValdations.md
+++ b/docs/Scheduling/EncounterValdations.md
@@ -7,16 +7,17 @@ title: Encounter Validations
 
 When an Encounter Service is created, it is validated to ensure it passes a number of validation rules:
 
-1. The date of the Encounter Service must be within the Start and End date of the Authorization.
+1. The date of the Encounter Service must be within the Start and End date of the Authorization Service.
 2. An Encounter Service cannot have more units in the given time period than the Authorization Service or Assignment allows.
-3. The Encounter Services for that service that day cannot exceed the MUE Limit for this service (as configured on the Insurance Plan Benefit).
-4. The duration on the Encounter Service must be between the min/max units required from the Insurance Plan Benefit.
+3. The Encounter Services for that patient that service that day cannot exceed the MUE Limit for this service (as configured on the Insurance Plan Benefit).
+4. The duration of the Encounter Service must be between the min/max units required on the Insurance Plan Benefit.
 5. The Practitioner Participants on an Encounter Service must have the required credentials for this service (as configured on the [Insurance Plan Benefit](../AdminSetup/InsurancePlan.md/#RequiredQualifications)).
-6. An Encounter Participant cannot overlap with another Encounter Participant.
-    - For example, a patient included as the encounter participant on both an encounter from 12:00 - 2:00 and an encounter from 1:30 - 4:30 would be invalid.
-    - Direction of Technician and Adaptive Behavior Treatment with Protocol Modification services are allowed to overlap with Direct Treatment services for the same patient when the Encounters are at the same location, or over telecare.
-7. Direction of Technician services must fully overlap with Direct Treatment sessions.
-8. Optional- when "Block Supervision Submission" on the [business unit](../AdminSetup/BusinessUnit.md) is set to Yes, a Direction of Technician session will fail validation until an overlapping Direct Treatment session (with the same location / telecare) is submitted. This puts additional accountability on BCBAs to encourage timely session submission for sessions they supervise.
+6. An Encounter Service cannot overlap with another Encounter Encounter Service for the same patient/practitioner.
+    - For example, an encounter service for patient John Doe from 12:00 - 2:00 would be an invalid overlap with an encounter service for patient John Doe from 1:30 - 4:30.
+    - For example, an encounter service for practitioner Robert Brown from 9:00 - 11:30 would be an invalid overlap with an encounter service for practitioner Robert Brown 11:15 - 2:15.
+    - Direction of Technician and Adaptive Behavior Treatment with Protocol Modification services are allowed to overlap with Direct Treatment or Group Behavior Treatment services for the same patient when the Encounters are at the same location, or over telecare.
+7. Direction of Technician sessions must fully overlap with Direct Treatment or Group Behavor Treatment sessions.
+8. Optional- when "Block Supervision Submission" on the [business unit](../AdminSetup/BusinessUnit.md) is set to Yes, a Direction of Technician session will fail validation until an overlapping Direct Treatment or Group Behavior Treatment session (with the same location / telecare) is submitted. This puts additional accountability on BCBAs to encourage timely session submission for sessions they supervise.
 <img src ="/img/BUblockSupervision.png" width="700"/>
 9. Optional- when "Grace Period Days" on the [business unit](../AdminSetup/BusinessUnit.md) is populated, the encounter service must be submitted within that many days after the scheduled date of the session.
 
@@ -29,7 +30,7 @@ When an Encounter Service is created, it is validated to ensure it passes a numb
 
 ## Invalid Single Encounters
 
-When an Encounter Service or Encounter Participant fails validation, in addition to the Validation Status being set to 'failed', a red banner will be displayed at the top of the screen on the Encounter, the failed Encounter Service, and/or the failed Encounter Participant. The banner can be expanded to view the validation that failed.
+When an Encounter Service fails validation, in addition to the Validation Status being set to 'failed', a red banner will be displayed at the top of the screen on the Encounter and the failed Encounter Service. The banner can be expanded to view the validation that failed.
 
 ## Invalid Recurring Encounters
 
@@ -49,12 +50,12 @@ On recurring encounters, if one or more child encounter occurrences are invalid 
 
 ## Rerun Validation
 
-To rerun validation, open the encounter service or encounter participant you'd like to revalidate, and click "Rerun Validation." Refresh the record to see the updated validation status.
+To rerun validation, open the encounter service you'd like to revalidate, and click "Rerun Validation." Refresh the record to see the updated validation status.
 
 To rerun validation on multiple records:
 
-1. Go to an encounter service or encounter participants view.
-2. Select the encounter services/participants you'd like to revalidate.
+1. Go to an encounter services view.
+2. Select the encounter services you'd like to revalidate.
 3. Click "Edit".
 4. Navigate to the "Header" tab on the form.
 5. Choose "Pending" as the validation status. Save the changes and the selected records will be revalidated.
@@ -62,8 +63,8 @@ To rerun validation on multiple records:
 ## Override Validation Failures
 Users with the Scheduling Admin [security role](../AdminSetup/SecurityRoles.md) can override validation failures to allow the practitioner to submit sessions that failed for certain reasons.
 
-1. Go to the failed encounter service or participant.
+1. Go to the failed encounter service.
 2. Go the Related > Encounter Validation Failure that has been approved to be overriden.
 3. Set "Override Allowed" to Yes. The validation failure record will remain active, but the session will not fail validation for this reason again.
 
-Overriden validatons display in a yellow banner on the encounter service or participant so it is clear that this session previously failed a validation and has since been allowed to pass.
+Overriden validatons display in a yellow banner on the encounter service so it is clear that this session previously failed a validation and has since been allowed to pass.

--- a/docs/Scheduling/SingleEncounters.md
+++ b/docs/Scheduling/SingleEncounters.md
@@ -64,9 +64,6 @@ To create an encounter participant, click 'New Encounter Practitioner' on the En
     - Patient
     - Practitioner
     - Related Contact
-- *Start Date/Time* - prepopulated with the start date/time of the Encounter you are adding the Encounter Participant to.
-- *Duration* - prepopulated with the duration of the Encounter you are adding the Encounter Participant to.
-- *End Date/Time* - prepopulated with the end date/time of the Encounter you are adding the Encounter Participant to.
 
 ### Encounter Location
 Th final step of creating an encounter is selecting the Location.
@@ -82,8 +79,6 @@ The Location on the Encounter will be included as the Place of Service on the Cl
 To update the timing of encounters, choose the **encounter service** for which the timing needs to be updated, and update the relevant fields. 
 
 - The encounter's start time will automatically update to the start time of the earliest encounter service under it, and the encounter's end time will update to the end time of the latest encounter service under it.
-
-- The practitioner encounter participant will automatically update to match the timing of the updated encounter service. The patient encounter participant will automatically update to the timing of the encounter (the earliest start time and latest end time of all encounter services under the encounter).
 
 ## Encounters for Other Time Zones
 A notification banner displays when your Dynamics Time Zone settings are set to a different time zone than the patient, to inform you that you are viewing timings in a different time zone than where the session took place.


### PR DESCRIPTION
removed timing/validation status from participants, added that group services count as allowed overlaps